### PR TITLE
Preserve content bottom padding on front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,9 @@ header .intro-text .skills {
 }
 
 .content {
-  padding: 0px;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
 }
 
 .plus-icon {


### PR DESCRIPTION
This adds more space between the bullet points and the footer at the front page which is more consistent with the other pages. I think it could actually use a little additional bottom padding here, but for now  it doesn't strike my eye anymore.
