### PR TITLE
Fix link for Scala on the JVM

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -48,7 +48,7 @@
           </a>
           <div class="navbar-custom-menu">
             <ul class="nav navbar-nav">
-              <li data-toggle="tooltip" data-placement="bottom" title="Scala on the JVM"><a href="http://get-scala.org"><img src="{{site.baseurl}}/resources/img/jvm.svg" height="50px"></img></a></li>
+              <li data-toggle="tooltip" data-placement="bottom" title="Scala on the JVM"><a href="http://scala-lang.org"><img src="{{site.baseurl}}/resources/img/jvm.svg" height="50px"></img></a></li>
               <li data-toggle="tooltip" data-placement="bottom" title="Scala in the browser"><a href="https://scala-js.org"><img src="{{site.baseurl}}/resources/img/js.svg" height="50px" style="padding:8px;"></img></a></li>
               <li data-toggle="tooltip" data-placement="bottom" title="Scala Native"><a href="http://scala-native.org"><img src="{{site.baseurl}}/resources/img/native.svg" height="50px" style="padding: 5px;"></img></a></li>
             </ul>


### PR DESCRIPTION
Sadly, get-scala.org is no more, and it appears that will be permanent.  Linking to scala-lang.org is better than a broken link.